### PR TITLE
using rendertexture coords for dithering lookup

### DIFF
--- a/PSX Dither.shader
+++ b/PSX Dither.shader
@@ -108,11 +108,10 @@
                 float ditherSize = _DitherPattern_TexelSize.w;
                 float ditherSteps = _DitherPattern_TexelSize.z/ditherSize;
 
-                float2 ditherBlockUV = i.uv;
-                ditherBlockUV.x %= (ditherSize / _ScreenParams.x);
-                ditherBlockUV.x /= (ditherSize / _ScreenParams.x);
-                ditherBlockUV.y %= (ditherSize / _ScreenParams.y);
-                ditherBlockUV.y /= (ditherSize / _ScreenParams.y);
+                float2 ditherBlockUV = i.uv;                ditherBlockUV.x %= (ditherSize / _MainTex_TexelSize.z);
+                ditherBlockUV.x /= (ditherSize / _MainTex_TexelSize.w);
+                ditherBlockUV.y %= (ditherSize / _MainTex_TexelSize.z);
+                ditherBlockUV.y /= (ditherSize / _MainTex_TexelSize.w);
                 ditherBlockUV.x /= ditherSteps;
 
                 // Dither each channel individually


### PR DESCRIPTION
https://answers.unity.com/questions/927964/can-shader-read-the-texture-size-without-scripting.html

{{TextureName}_TexelSize - a float4 property contains texture size information:

x contains 1.0/width
y contains 1.0/height
z contains width
w contains height